### PR TITLE
Fix a problem with % and negative metrics

### DIFF
--- a/src/main/java/com/appdynamics/extensions/redis/utils/InfoMapExtractor.java
+++ b/src/main/java/com/appdynamics/extensions/redis/utils/InfoMapExtractor.java
@@ -14,13 +14,13 @@ import java.util.Map;
 
 public class InfoMapExtractor {
 
-    public Map<String, String> extractInfoAsHashMap(String info, String sectionName){
+    public Map<String, String> extractInfoAsHashMap(String info, String sectionName) {
         Map<String, String> infoMap = Maps.newHashMap();
         Splitter sectionSplitter = Splitter.on('#')
-                                           .omitEmptyStrings()
-                                           .trimResults();
-        for(String section : sectionSplitter.split(info)){
-            if(!section.toLowerCase().startsWith(sectionName.toLowerCase())) {
+                .omitEmptyStrings()
+                .trimResults();
+        for (String section : sectionSplitter.split(info)) {
+            if (!section.toLowerCase().startsWith(sectionName.toLowerCase())) {
                 continue;
             }
             return sectionMapGenerator(section, sectionName);
@@ -31,17 +31,26 @@ public class InfoMapExtractor {
     private Map<String, String> sectionMapGenerator(String sectionData, String sectionName) {
         Map<String, String> infoMap = Maps.newHashMap();
         Splitter lineSplitter = Splitter.on(System.getProperty("line.separator"))
-                                        .omitEmptyStrings()
-                                        .trimResults();
+                .omitEmptyStrings()
+                .trimResults();
         for (String line : lineSplitter.split(sectionData)) {
             if (line.toLowerCase().startsWith(sectionName)) {
                 continue;
             }
-            String infoLine[] = line.split(":");
-            if (infoLine.length == 2) {
-                infoMap.put(infoLine[0].trim(), infoLine[1].trim());
+            String[] infoLine = line.split(":");
+            if (infoLine.length == 2 && positiveNumber(infoLine[1].trim())) {
+                infoMap.put(infoLine[0].trim(), removeInvalidCharacters(infoLine[1].trim()));
             }
+
         }
         return infoMap;
+    }
+
+    private boolean positiveNumber(String trim) {
+        return !trim.contains("-");
+    }
+
+    private String removeInvalidCharacters(String metric) {
+        return metric.replaceAll("%", "");
     }
 }


### PR DESCRIPTION
Fix the problem when used_memory_peak_perc is treated as invalid due to % in the string value. I removed % from any metric to fix the problem. Additionally, I created a filter for negative values.